### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ffmpeg
 matplotlib
 nd_line
-numpy
+numpy==1.26.4
 opencv-python
 openpyxl
 pandas


### PR DESCRIPTION
as mentioned in issue #55. This is a temp fix.


I am trying to get the ASCENT up and running.

=================
I encountered an error due to the use of np.math.hypot, which was removed in NumPy 2.0.0. This function was available in NumPy versions up to 1.26.x but was deprecated and replaced with np.hypot in later versions.

I resolved the issue by downgrading NumPy to version 1.26.4, the latest version that still includes np.math.hypot.

Some thoughts:
Update ASCENT codebase to use np.hypot instead of np.math.hypot for future compatibility.
Add a version check or try-except block to handle both old and new NumPy versions. #55 